### PR TITLE
Add help option to RemoteDesktop

### DIFF
--- a/src/apps/remotedesktop/RemoteDesktop.cpp
+++ b/src/apps/remotedesktop/RemoteDesktop.cpp
@@ -28,12 +28,25 @@ print_usage(const char *app)
 	printf("usage:\t%s --listenOnly [-p <listenPort>]\n", app);
 	printf("\t%s <user@host> [-p <listenPort>] [-s <sshPort>] [-c <command>]\n",
 		app);
+	printf("\t%s--help\n", app);
 }
 
 
 int
 main(int argc, char *argv[])
 {
+	if (strcmp(argv[1], "--help") == 0)
+	{
+		printf("Usage: %s [OPTIONS]...\n", argv[0]);
+		printf("Connect to & run applications from a different computer\n\n");
+		printf("Arguments available for use:\n\n");
+		printf("\t-p\t\tspecify the port to communicate on\n");
+		printf("\t-c\t\tsend a command to the other computer\n");
+		printf("\t-s\t\tuse ssh & specify the ssh port to communicate on\n");
+		
+		return 1;
+	}
+	
 	if (argc < 2) {
 		print_usage(argv[0]);
 		return 1;


### PR DESCRIPTION
In this PR, I add a simple "--help" option for RemoteDesktop. I keep the documentation pretty simple, but it is enough to inform the user how to use RemoteDesktop.