### PR TITLE
Show warning when user not connected to touchpad

### DIFF
--- a/src/preferences/touchpad/TouchpadPref.h
+++ b/src/preferences/touchpad/TouchpadPref.h
@@ -37,7 +37,8 @@ public:
 
 			touchpad_settings&	Settings()
 									{ return fSettings; }
-
+			bool 				IsTouchPadConnected()
+									{ return fConnected; }
 			status_t			UpdateSettings();
 
 private:
@@ -46,7 +47,6 @@ private:
 			status_t			SaveSettings();
 
 			status_t			ConnectToTouchPad();
-
 			bool 				fConnected;
 			BInputDevice* 		fTouchPad;
 

--- a/src/preferences/touchpad/TouchpadPrefView.cpp
+++ b/src/preferences/touchpad/TouchpadPrefView.cpp
@@ -117,6 +117,7 @@ TouchpadView::MouseUp(BPoint point)
 	} else {
 		if (GetRightScrollRatio() > kSoftScrollLimit)
 			fXScrollRange = fOldXScrollRange;
+
 		if (GetBottomScrollRatio() > kSoftScrollLimit)
 			fYScrollRange = fOldYScrollRange;
 		DrawSliders();
@@ -271,6 +272,8 @@ TouchpadPrefView::TouchpadPrefView()
 	SetupView();
 	// set view values
 	SetValues(&fTouchpadPref.Settings());
+	if (fTouchpadPref.IsTouchPadConnected() == false)
+		ShowTouchpadWarning();
 }
 
 
@@ -370,7 +373,6 @@ TouchpadPrefView::SetupView()
 
 	fTouchpadView = new TouchpadView(BRect(0, 0, 130, 120));
 	fTouchpadView->SetExplicitMaxSize(BSize(130, 120));
-
 	// Create the "Mouse Speed" slider...
 	fScrollAccelSlider = new BSlider("scroll_accel",
 		B_TRANSLATE("Acceleration"),
@@ -484,4 +486,14 @@ TouchpadPrefView::SetValues(touchpad_settings* settings)
 	fScrollStepYSlider->SetValue(20 - settings->scroll_ystepsize / 2);
 	fScrollAccelSlider->SetValue(settings->scroll_acceleration);
 	fTapSlider->SetValue(settings->tapgesture_sensibility);
+}
+
+
+void
+TouchpadPrefView::ShowTouchpadWarning()
+{
+	BAlert* alert = new BAlert(B_TRANSLATE("Touchpad Status"),
+		B_TRANSLATE("Currently, Touchpad is not connected. So changes will not see."),
+		B_TRANSLATE("OK"), NULL, NULL, B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+		alert->Go();
 }

--- a/src/preferences/touchpad/TouchpadPrefView.h
+++ b/src/preferences/touchpad/TouchpadPrefView.h
@@ -102,6 +102,7 @@ private:
 			BButton*		fRevertButton;
 
 			TouchpadPref	fTouchpadPref;
+			void 			ShowTouchpadWarning();
 };
 
 


### PR DESCRIPTION
Show warning to a user while opening touchpad preference when it is not connected.

When the touchpad is not connected but the user click on the touchpad preferences.

![warning](https://user-images.githubusercontent.com/31319212/55287046-b0b5aa80-53c1-11e9-90d0-d4a24e6974e0.png)

After clicking on OK.
![after_ok](https://user-images.githubusercontent.com/31319212/55287101-4c471b00-53c2-11e9-87af-2df92b099eee.png)

The user will see the preferences but didn't feel any change until it will connect to touchpad. 

