### PR TITLE
remove mention of OpenBeOS newsletter in HowTo Doc

### DIFF
--- a/docs/user/HOWTO
+++ b/docs/user/HOWTO
@@ -7,7 +7,7 @@ here, not development related docs (those belong in trunk/docs/develop).
 
 This HOWTO only explains how to include your kit into the "Haiku Book", it
 is not a Doxygen tutorial. For information about using Doxygen, see the Doxygen
-manual, www.doxygen.org, and OpenBeOS newletters 31 and 29.
+manual, www.doxygen.org.
 
 There are two ways to document your kit:
 


### PR DESCRIPTION
These newsletters do not seem to be available online. I was unable to find them after quite a bit of searching.  If one of the devs have them, they should be archived somewhere online so that they can be viewed.  Until then, leaving the mention will waste potential committers time by having them search for them.