### PR TITLE
Fix serial re-init on x86_64

### DIFF
--- a/src/system/boot/platform/efi/arch/x86_64/arch_start.cpp
+++ b/src/system/boot/platform/efi/arch/x86_64/arch_start.cpp
@@ -145,9 +145,6 @@ arch_start_kernel(addr_t kernelEntry)
 	// entry.
 
 	dprintf("Calling ExitBootServices. So long, EFI!\n");
-
-	// Re-init and activate serial in a horrific post-EFI landscape. Clowns roam the land freely.
-	serial_init();
 	serial_disable();
 
 	while (true) {
@@ -169,7 +166,8 @@ arch_start_kernel(addr_t kernelEntry)
 	arch_mmu_post_efi_setup(memory_map_size, memory_map,
 		descriptor_size, descriptor_version);
 
-	// Restart serial. gUART only until we get into the kernel
+	// Re-init and activate serial in a horrific post-EFI landscape. Clowns roam the land freely.
+	serial_init();
 	serial_enable();
 
 	smp_boot_other_cpus(final_pml4, kernelEntry, (addr_t)&gKernelArgs);


### PR DESCRIPTION
b965b55 added `serial_init` to be called **after** calling the `ExitBootServices` on all the archs except of x86_64. This commit fixes it.

Can someone from the dev team bring it to Gerrit please? Thanks!

