### PR TITLE
Fix potential memory leak in HashedObjectCache

### DIFF
--- a/src/system/kernel/slab/HashedObjectCache.cpp
+++ b/src/system/kernel/slab/HashedObjectCache.cpp
@@ -180,13 +180,18 @@ HashedObjectCache::_ResizeHashTableIfNeeded(uint32 flags)
 
 		if (buffer != NULL) {
 			if (hash_table.ResizeNeeded() == hashSize) {
-				void* oldHash;
+				void* oldHash = NULL;
 				hash_table.Resize(buffer, hashSize, true, &oldHash);
 				if (oldHash != NULL) {
 					Unlock();
 					slab_internal_free(oldHash, flags);
 					Lock();
 				}
+			} else {
+				// Condition changed, our allocated buffer is not suitable.
+				Unlock();
+				slab_internal_free(buffer, flags);
+				Lock();
 			}
 		}
 	}


### PR DESCRIPTION
A potential memory leak in `HashedObjectCache::_ResizeHashTableIfNeeded()` was fixed. If a new buffer for the hash table was allocated, but subsequently the conditions for resizing changed (e.g., due to another thread performing the resize or the required size changing), the newly allocated buffer was not freed.

The fix adds an `else` path to free the unused buffer in such scenarios.

An earlier incorrect modification to `CreateSlab()` was reverted as the original code was found to be correct upon closer inspection.