### PR TITLE
Fix #11138 restore _text field when loading BAlert                   …

### DIFF
--- a/src/kits/interface/Alert.cpp
+++ b/src/kits/interface/Alert.cpp
@@ -137,6 +137,10 @@ BAlert::BAlert(BMessage* data)
 	fAlertValue = -1;
 
 	fTextView = (BTextView*)FindView("_tv_");
+	  
+	const char*text;
+	if(data->FindString("_text",&text)==B_OK)
+		fTextView->SetText(text);
 
 	// TODO: window loses default button on dearchive!
 	// TODO: ButtonAt() doesn't work afterwards (also affects shortcuts)


### PR DESCRIPTION
Fix #11138 restore _text field when loading BAlert

irc channel -kishan
gerrit - kishan(Kishan Gowda D K)
due to some miss configuration so i am unable to push directly to gerrit 
please do consider this problem
thank u 
       
 #gsoc2026